### PR TITLE
add optimize.sh script and add it to the publish script.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 secrets.tfvars
 .terraform
 .idea
-elm-stuff
 *.html
 *.iml
+
+# elm build artifacts
+elm-stuff/
+dist/
+assets/elm.min.js

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 secrets.tfvars
 .terraform
 .idea
-*.html
 *.iml
 
 # elm build artifacts

--- a/assets/index.html
+++ b/assets/index.html
@@ -1,17 +1,15 @@
 <!DOCTYPE HTML>
 <html>
-<head>
-  <meta charset="UTF-8">
-  <title>Main</title>
-  <style>body { padding: 0; margin: 0; }</style>
-</head>
-
-<body>
-
-<pre id="elm"></pre>
-<script src="elm.min.js"></script>
-<script>
-	var app = Elm.Main.init({ node: document.getElementById("elm") });
-</script>
-</body>
+  <head>
+    <meta charset="UTF-8">
+    <title>Main</title>
+    <style>body { padding: 0; margin: 0; }</style>
+  </head>
+  <body>
+    <pre id="elm"></pre>
+    <script src="elm.min.js"></script>
+    <script>
+      var app = Elm.Main.init({ node: document.getElementById("elm") });
+    </script>
+  </body>
 </html>

--- a/assets/index.html
+++ b/assets/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Main</title>
+  <style>body { padding: 0; margin: 0; }</style>
+</head>
+
+<body>
+
+<pre id="elm"></pre>
+<script src="elm.min.js"></script>
+<script>
+	var app = Elm.Main.init({ node: document.getElementById("elm") });
+</script>
+</body>
+</html>

--- a/publish/optimize.sh
+++ b/publish/optimize.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -e
+
+js="../dist/elm.js"
+min="../assets/elm.min.js"
+
+
+# build the elm app (using optimized flag)
+elm make --optimize --output=$js ../src/Main.elm
+
+# check to make sure uglifyjs is installed
+if ! command -v uglifyjs &> /dev/null
+then
+    echo "\033[0;31muglifyjs could not be found. Install uglifyjs by running:"
+    echo "\033[0;31mnpm install uglify-js --global"
+    exit
+fi
+
+# uglify the js (once to compress and again to mangle)
+uglifyjs $js --compress "pure_funcs=[F2,F3,F4,F5,F6,F7,F8,F9,A2,A3,A4,A5,A6,A7,A8,A9],pure_getters,keep_fargs=false,unsafe_comps,unsafe" | uglifyjs --mangle > $min
+
+# echo metrics to brag about how much better the optimized/minified app is
+echo "Initial size:  $(cat $js | wc -c) bytes"
+echo "Minified size: $(cat $min | wc -c) bytes"

--- a/publish/publish.sh
+++ b/publish/publish.sh
@@ -1,2 +1,3 @@
+sh optimize.sh
 sh publish-assets.sh
 sh publish-index.sh


### PR DESCRIPTION
This PR modifies the build script a bit to supercharge the app with the magic of elm's optimizer. 

<img width="402" alt="Screen Shot 2020-10-22 at 4 40 35 PM" src="https://user-images.githubusercontent.com/20078622/96940707-525d8a80-1485-11eb-9bf7-adb0c16e01c4.png">

Merge this and you'll have the following benefits:
- No more crappy warning in webconsole
- Much faster page load times (which might make a larger difference than you'd think, especially for mobile 3G/4G connections)

If you wanna take it a step further:
- Gzip the minified js